### PR TITLE
Convert existing packages to more standard (like) packages and Refact…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openanime/release-server-publisher",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "OpenAnime release server publisher for Electron Forge",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -27,9 +27,10 @@
     "dependencies": {
         "@electron-forge/publisher-base": "^7.4.0",
         "@electron-forge/shared-types": "^7.4.0",
-        "consola": "^3.2.3",
-        "ofetch": "^1.3.4",
-        "pathe": "^1.1.2"
+        "axios": "^1.7.7",
+        "axios-retry": "^4.5.0",
+        "pino": "^9.4.0",
+        "pino-pretty": "^11.2.2"
     },
     "engines": {
         "node": ">= 20"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,196 +1,221 @@
 import { readSync, statSync, openSync, closeSync } from 'node:fs';
+import { basename } from 'node:path';
+import pino from 'pino';
+import pretty from 'pino-pretty';
+import axios, { Axios } from 'axios';
+import axiosRetry from 'axios-retry';
 
-import { basename } from 'pathe';
-import { ofetch } from 'ofetch';
-import consola from 'consola';
+const logger = pino(
+    {
+        level: process.env.NODE_ENV === 'development' ? 'debug' : 'info',
+        customLevels: {
+            success: 35, // info + 5
+        },
+    },
+    pretty(),
+);
 
 import { PublisherBase, type PublisherOptions } from '@electron-forge/publisher-base';
 import type { ForgePlatform } from '@electron-forge/shared-types';
 
-export type ORSChannel = 'stable' | 'beta' | 'alpha' | 'rc';
+export type ReleaseChannel = 'stable' | 'beta' | 'alpha' | 'rc';
 
 export interface PublisherOpenAnimeConfig {
     baseUrl: string;
     username: string;
     password: string;
-    channel?: ORSChannel;
+    channel?: ReleaseChannel;
     chunkSizeInMb?: number;
 }
 
-export interface ORSAsset {
+export interface ReleaseAsset {
     name: string;
     platform: ForgePlatform;
 }
 
-export interface ORSRelease {
+export interface ReleaseInfo {
     version: string;
-    channel: ORSChannel;
+    channel: ReleaseChannel;
     changeLog: string;
     createdAt: string;
-    assets: ORSAsset[];
+    assets: ReleaseAsset[];
 }
 
 export default class PublisherOpenAnime extends PublisherBase<PublisherOpenAnimeConfig> {
     name = 'openanime-release-server';
 
     async publish({ makeResults, setStatusLine }: PublisherOptions): Promise<void> {
-        const { config } = this;
+        const {
+            baseUrl,
+            username,
+            password,
+            channel: configuredChannel,
+            chunkSizeInMb: chunkSizeMb = 10,
+        } = this?.config ?? {};
 
-        if (!config.baseUrl || !config.username || !config.password) {
-            consola.error(new Error('Missing required configuration options for ORS'));
+        if (!baseUrl || !username || !password) {
+            return logger.error('Missing required configuration options for release server');
         }
 
-        consola.info('Attempting to authenticate to ORS');
+        logger.info('Attempting to authenticate with release server');
 
-        const apiFetch = ofetch.create({ baseURL: `${config.baseUrl}/api` });
+        const apiClient = axios.create({ baseURL: `${baseUrl}/api` });
+
+        axiosRetry(apiClient, { retries: 3 });
 
         try {
-            const { jwt } = await apiFetch<{ jwt: string }>('/login', {
-                method: 'POST',
-                body: {
-                    username: config.username,
-                    password: config.password,
-                },
+            const {
+                data: { jwt },
+            } = await apiClient.post<{ jwt: string }>('/login', {
+                username,
+                password,
             });
 
             for (const makeResult of makeResults) {
-                const { packageJSON } = makeResult;
+                const { packageJSON, artifacts, platform } = makeResult;
 
-                const artifacts = makeResult.artifacts.filter(
+                const validArtifacts = artifacts.filter(
                     (artifactPath) => basename(artifactPath).toLowerCase() !== 'releases',
                 );
 
-                let channel = 'stable';
-                if (config.channel) {
-                    channel = config.channel;
-                } else if (packageJSON.version.includes('rc')) {
-                    channel = 'rc';
-                } else if (packageJSON.version.includes('beta')) {
-                    channel = 'beta';
-                } else if (packageJSON.version.includes('alpha')) {
-                    channel = 'alpha';
-                }
-
-                const version = packageJSON.version.replace(/-(stable|beta|alpha|rc)/, '');
-
-                const releases = await apiFetch<ORSRelease[]>('/releases');
+                const channel = configuredChannel ?? this.extractChannel(packageJSON.version);
+                const version = this.extractVersion(packageJSON.version, channel);
+                const { data: releases } = await apiClient.get<ReleaseInfo[]>('/releases');
 
                 const existingRelease = releases.find(
                     (release) => release.version === version && release.channel === channel,
                 );
 
-                if (!existingRelease) {
-                    try {
-                        await apiFetch('/releases', {
-                            method: 'POST',
-                            body: {
-                                version,
-                                channel,
-                                changeLog: 'Electron Forge Release',
-                            },
-                            headers: {
-                                Authorization: jwt,
-                            },
-                        });
+                if (!existingRelease) await this.createRelease(apiClient, version, channel, jwt);
 
-                        consola.success(`Release ${version} created on server`);
-                    } catch {
-                        consola.error(new Error('Failed to create release on server'));
-                    }
-                }
+                let uploadedCount = 0;
 
-                let uploaded = 0;
-
-                const updateStatusLine = () => {
-                    setStatusLine(`Uploading distributable (${uploaded}/${artifacts.length})`);
-                };
-
-                updateStatusLine();
+                const updateStatus = () =>
+                    setStatusLine(
+                        `Uploading artifact (${++uploadedCount}/${validArtifacts.length})`,
+                    );
 
                 await Promise.all(
-                    artifacts.map(async (artifactPath: string) => {
+                    validArtifacts.map(async (artifactPath) => {
                         const fileName = basename(artifactPath);
 
-                        if (existingRelease) {
-                            const existingAsset = existingRelease.assets.find(
-                                (asset) =>
-                                    asset.name === fileName &&
-                                    asset.platform === makeResult.platform,
-                            );
-
-                            if (existingAsset) {
-                                consola.info(`Asset ${fileName} already exists on server`);
-
-                                uploaded++;
-                                updateStatusLine();
-
-                                return;
-                            }
+                        if (
+                            existingRelease &&
+                            this.doesAssetExist(existingRelease, fileName, platform)
+                        ) {
+                            logger.info(`Asset ${fileName} already exists on the server`);
+                            return updateStatus();
                         }
 
-                        consola.info(`Uploading asset ${fileName} to server`);
+                        const uploadSuccess = await this.uploadAsset(
+                            apiClient,
+                            artifactPath,
+                            fileName,
+                            version,
+                            channel,
+                            platform,
+                            jwt,
+                            chunkSizeMb,
+                        );
 
-                        const fileChunkSize = (config.chunkSizeInMb ?? 10) * 1024 * 1024;
-
-                        const fileSize = statSync(artifactPath).size;
-                        const totalChunks = Math.ceil(fileSize / fileChunkSize);
-
-                        let success = true;
-
-                        for (let i = 0; i < totalChunks; i++) {
-                            let buffer = Buffer.alloc(fileChunkSize);
-                            const fileDescriptor = openSync(artifactPath, 'r');
-
-                            try {
-                                const bytesRead = readSync(fileDescriptor, buffer, {
-                                    length: fileChunkSize,
-                                    position: i * fileChunkSize,
-                                });
-
-                                if (bytesRead < fileChunkSize) {
-                                    buffer = buffer.subarray(0, bytesRead);
-                                }
-                            } finally {
-                                closeSync(fileDescriptor);
-                            }
-
-                            const formData = new FormData();
-
-                            formData.append('currentChunk', (i + 1).toString());
-                            formData.append('totalChunks', totalChunks.toString());
-                            formData.append('platform', makeResult.platform);
-                            formData.append('file', new Blob([buffer]), basename(artifactPath));
-
-                            try {
-                                await apiFetch(`/releases/${channel}/${version}/assets`, {
-                                    method: 'POST',
-                                    body: formData,
-                                    headers: {
-                                        Authorization: jwt,
-                                    },
-                                    retry: 3,
-                                });
-                            } catch {
-                                success = false;
-                                break;
-                            }
-                        }
-
-                        if (success) {
-                            consola.success(`Asset ${fileName} uploaded to server`);
+                        if (uploadSuccess) {
+                            logger.success(`Asset ${fileName} uploaded successfully`);
                         } else {
-                            consola.error(
-                                new Error(`Failed to upload asset ${fileName} to server`),
-                            );
+                            logger.error(`Failed to upload asset ${fileName}`);
                         }
 
-                        uploaded++;
-                        updateStatusLine();
+                        updateStatus();
                     }),
                 );
             }
         } catch {
-            consola.error(new Error('Invalid credentials for ORS'));
+            logger.error(new Error('Invalid credentials for release server'));
         }
+    }
+
+    extractChannel(version: string): ReleaseChannel {
+        return ['stable', 'beta', 'alpha', 'rc'].find((c) => version.includes(c)) as ReleaseChannel;
+    }
+
+    extractVersion(version: string, channel: ReleaseChannel): string {
+        return version.replace(`-${channel}`, '');
+    }
+
+    async createRelease(apiClient: Axios, version: string, channel: ReleaseChannel, jwt: string) {
+        try {
+            if (
+                (
+                    await apiClient.post(
+                        '/releases',
+                        {
+                            version,
+                            channel,
+                            changeLog: 'Electron Forge Release',
+                        },
+                        {
+                            headers: { Authorization: jwt },
+                        },
+                    )
+                ).status !== 201
+            )
+                throw new Error();
+
+            logger.success(`Release ${version} created successfully`);
+        } catch {
+            logger.error('Failed to create release on the server');
+        }
+    }
+
+    doesAssetExist(existingRelease: ReleaseInfo, fileName: string, platform: ForgePlatform) {
+        return existingRelease.assets.some(
+            (asset) => asset.name === fileName && asset.platform === platform,
+        );
+    }
+
+    async uploadAsset(
+        apiClient: Axios,
+        artifactPath: string,
+        fileName: string,
+        version: string,
+        channel: ReleaseChannel,
+        platform: ForgePlatform,
+        jwt: string,
+        chunkSizeMb: number,
+    ): Promise<boolean> {
+        const fileChunkSize = chunkSizeMb * 1024 * 1024;
+        const totalChunks = Math.ceil(statSync(artifactPath).size / fileChunkSize);
+
+        for (let i = 0; i < totalChunks; i++) {
+            let buffer = Buffer.alloc(fileChunkSize);
+            const fileDescriptor = openSync(artifactPath, 'r');
+
+            try {
+                const bytesRead = readSync(fileDescriptor, buffer, {
+                    length: fileChunkSize,
+                    position: i * fileChunkSize,
+                });
+                if (bytesRead < fileChunkSize) {
+                    buffer = buffer.subarray(0, bytesRead);
+                }
+            } finally {
+                closeSync(fileDescriptor);
+            }
+
+            const formData = new FormData();
+            formData.append('currentChunk', (i + 1).toString());
+            formData.append('totalChunks', totalChunks.toString());
+            formData.append('platform', platform);
+            formData.append('file', new Blob([buffer]), fileName);
+
+            try {
+                await apiClient.post(`/releases/${channel}/${version}/assets`, formData, {
+                    headers: { Authorization: jwt },
+                });
+            } catch {
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
…or Release Publishing Logic

This commit brings several notable modifications:
- Dependencies have been updated, with the replacement of 'consola' with 'pino' and 'pino-pretty' for logging, and 'ofetch' with 'axios' and 'axios-retry' for more reliable API requests.
- The logic for publishing releases has undergone significant restructuring. The readability and maintainability of the code have been improved by abstracting logic into separate functions and optimizing the structure of the code.
- Checks before uploading artifacts and intelligent error handling have been added to improve the robustness of the code.

These changes aim to improve the yet maintain the overall functionality of the 'openanime-release-server' module. The shift to more popular and actively maintained libraries like 'axios' and 'pino' enhances the package's long-term viability while also optimizing performance and reliability.